### PR TITLE
Change "Enter" submit logic

### DIFF
--- a/apps/web/src/components/Main.tsx
+++ b/apps/web/src/components/Main.tsx
@@ -344,7 +344,8 @@ export default function Main({ sidebarOpen }: { sidebarOpen: boolean }) {
                 autoFocus: true,
                 onChange: onValueChange,
                 onKeyDown: (e) => {
-                  if (e.key === "Enter") {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
                     onSend();
                   }
                 },
@@ -389,6 +390,7 @@ export default function Main({ sidebarOpen }: { sidebarOpen: boolean }) {
                 onChange: (e) => setValue(e.target.value),
                 onKeyDown: (e) => {
                   if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
                     onSend();
                   }
                 },
@@ -508,6 +510,7 @@ export function Chat({
               onChange: onValueChange,
               onKeyDown: (e) => {
                 if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
                   askQuestion();
                 }
               },

--- a/apps/web/src/components/Main.tsx
+++ b/apps/web/src/components/Main.tsx
@@ -388,7 +388,7 @@ export default function Main({ sidebarOpen }: { sidebarOpen: boolean }) {
                 autoFocus: true,
                 onChange: (e) => setValue(e.target.value),
                 onKeyDown: (e) => {
-                  if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                  if (e.key === "Enter" && !e.shiftKey) {
                     onSend();
                   }
                 },
@@ -507,7 +507,7 @@ export function Chat({
               autoFocus: true,
               onChange: onValueChange,
               onKeyDown: (e) => {
-                if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                if (e.key === "Enter" && !e.shiftKey) {
                   askQuestion();
                 }
               },


### PR DESCRIPTION
This PR enables submit on "Enter" in the textbox and newlines with (Shift + Enter). Following common chat box convention.