### PR TITLE
chore: remove @cloudflare/ai package

### DIFF
--- a/apps/cf-ai-backend/package.json
+++ b/apps/cf-ai-backend/package.json
@@ -9,7 +9,7 @@
 		"unsafe-reset-vector-db": "wrangler vectorize delete  supermem-vector && wrangler vectorize create --dimensions=1536 supermem-vector-1 --metric=cosine"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20240222.0",
+		"@cloudflare/workers-types": "^4.20240502.0",
 		"typescript": "^5.0.4",
 		"wrangler": "^3.0.0"
 	}

--- a/apps/cf-ai-backend/src/OpenAIEmbedder.ts
+++ b/apps/cf-ai-backend/src/OpenAIEmbedder.ts
@@ -1,5 +1,3 @@
-import { AiTextGenerationOutput } from '@cloudflare/ai/dist/ai/tasks/text-generation';
-
 interface OpenAIEmbeddingsParams {
 	apiKey: string;
 	modelName: string;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@cloudflare/next-on-pages": "1",
-    "@cloudflare/workers-types": "^4.20240329.0",
+    "@cloudflare/workers-types": "^4.20240502.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@auth/d1-adapter": "^0.6.0",
     "@auth/drizzle-adapter": "^0.7.0",
-    "@cloudflare/ai": "^1.0.52",
     "@cloudflare/next-on-pages-next-dev": "^0.0.1",
     "@cloudflare/puppeteer": "^0.0.6",
     "@crxjs/vite-plugin": "^1.0.14",


### PR DESCRIPTION
This bumps `workers-types`, and then removes the no longer needed `@cloudflare/ai` package. That package is now deprecated:

https://developers.cloudflare.com/workers-ai/changelog/