### PR TITLE
fix: Cta component background color

### DIFF
--- a/apps/web/app/(landing)/Cta.tsx
+++ b/apps/web/app/(landing)/Cta.tsx
@@ -24,7 +24,7 @@ function Cta() {
         height={1405}
         priority
         draggable="false"
-        className="absolute z-[-2] hidden select-none rounded-3xl bg-black md:block lg:w-[80%]"
+        className="absolute z-[-2] hidden select-none rounded-3xl bg-background md:block lg:w-[80%]"
       />
       <h1 className="z-20 mt-4 text-center text-5xl font-medium tracking-tight text-white">
         Your bookmarks are collecting dust.


### PR DESCRIPTION
### Summary

Fixes the Call to Action component background color by changing it from black to secondary background color.

### Details

- Updated the background color of the Call to Action component from black to secondary background color.
- Improved the visual consistency by matching the background color with the design.
- Modified the CSS class in Cta.tsx to reflect the new background color setting.
- Included before and after images to illustrate the color change.


> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
Call to action background image has rounded with bg color as black on all four corners.

<img width="190" alt="image" src="https://github.com/Dhravya/supermemory/assets/38828053/785dc9b4-4aba-404e-a257-dc72b8f0a05e">

So, i changed to bg secondary to match

<img width="217" alt="image" src="https://github.com/Dhravya/supermemory/assets/38828053/ff88c2f3-be40-4754-9d3d-85d405a53663">


</details>

