### PR TITLE
feat: profile page skeleton

### DIFF
--- a/apps/web/app/(dash)/header.tsx
+++ b/apps/web/app/(dash)/header.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import Logo from "../../public/logo.svg";
-import { AddIcon, ChatIcon } from "@repo/ui/icons";
+import { ChatIcon } from "@repo/ui/icons";
 
 import DynamicIsland from "./dynamicisland";
-import { db } from "@/server/db";
 import { getChatHistory } from "../actions/fetchers";
 
-async function Header() {
+async function Header({ userId }: { userId: string }) {
   const chatThreads = await getChatHistory();
 
   if (!chatThreads.success || !chatThreads.data) {
@@ -56,6 +55,25 @@ async function Header() {
               </div>
             </div>
           </div>
+
+          <Link href={`/user/ + ${userId}`}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              className="lucide lucide-circle-user-round cursor-pointer"
+            >
+              <path d="M18 20a6 6 0 0 0-12 0" />
+              <circle cx="12" cy="10" r="4" />
+              <circle cx="12" cy="12" r="10" />
+            </svg>
+          </Link>
         </div>
       </div>
     </div>

--- a/apps/web/app/(dash)/layout.tsx
+++ b/apps/web/app/(dash)/layout.tsx
@@ -14,7 +14,7 @@ async function Layout({ children }: { children: React.ReactNode }) {
   return (
     <main className="h-screen flex flex-col">
       <div className="fixed top-0 left-0 w-full">
-        <Header />
+        <Header userId={info.user?.id || ""} />
       </div>
 
       <Menu />

--- a/apps/web/app/(dash)/user/[userId]/page.tsx
+++ b/apps/web/app/(dash)/user/[userId]/page.tsx
@@ -1,0 +1,46 @@
+import { getUserData } from "@/app/actions/fetchers";
+
+async function Page({ params }: { params: { userId: string } }) {
+  const userData = await getUserData();
+
+  if (userData.error) {
+    return <>Page Error Occured!</>;
+  }
+
+  return (
+    <div className="max-w-3xl h-full  flex mx-auto w-full flex-col py-24 px-2">
+      <p className="text-2xl text-primary py-2">Profile Settings</p>
+      <section className="p-4 flex flex-col gap-4 w-full bg-secondary rounded-md">
+        <label htmlFor="userName" className="gap-2">
+          <div className="opacity-70 text-md">Name</div>
+          <input
+            type="text"
+            value={userData.data?.name || ""}
+            disabled
+            className="bg-background py-1 px-2 rounded-sm text-lg"
+          />
+        </label>
+        <label htmlFor="email" className="">
+          <div className="opacity-70 text-md">Email</div>
+          <button
+            disabled
+            className="bg-background py-1 px-2 rounded-sm text-lg opacity-50"
+          >
+            {userData.data?.email}
+          </button>
+        </label>
+        <label htmlFor="telegramId" className="items-center">
+          <div className="opacity-70 text-md">Telegram Id</div>
+          <button
+            disabled
+            className="bg-background rounded-sm py-1 px-2 opacity-50 text-lg"
+          >
+            {userData.data?.telegramId ? "Linked" : "Not Linked"}
+          </button>
+        </label>
+      </section>
+    </div>
+  );
+}
+
+export default Page;

--- a/apps/web/app/actions/fetchers.ts
+++ b/apps/web/app/actions/fetchers.ts
@@ -9,6 +9,7 @@ import {
   Content,
   contentToSpace,
   storedContent,
+  User,
   users,
 } from "../../server/db/schema";
 import { ServerActionReturnType, Space } from "./types";
@@ -38,7 +39,7 @@ export const getSpaces = async (): ServerActionReturnType<Space[]> => {
 };
 
 export const getAllMemories = async (
-  freeMemoriesOnly: boolean = false,
+  freeMemoriesOnly: boolean = false
 ): ServerActionReturnType<Content[]> => {
   const data = await auth();
 
@@ -67,9 +68,9 @@ export const getAllMemories = async (
           storedContent.id,
           db
             .select({ contentId: contentToSpace.contentId })
-            .from(contentToSpace),
-        ),
-      ),
+            .from(contentToSpace)
+        )
+      )
     )
     .execute();
 
@@ -102,7 +103,7 @@ export const getAllUserMemoriesAndSpaces = async (): ServerActionReturnType<{
 };
 
 export const getFullChatThread = async (
-  threadId: string,
+  threadId: string
 ): ServerActionReturnType<ChatHistory[]> => {
   const data = await auth();
 
@@ -114,7 +115,7 @@ export const getFullChatThread = async (
   const thread = await db.query.chatThreads.findFirst({
     where: and(
       eq(chatThreads.id, threadId),
-      eq(chatThreads.userId, data.user.id),
+      eq(chatThreads.userId, data.user.id)
     ),
   });
 
@@ -154,7 +155,7 @@ export const getFullChatThread = async (
           sources: sources ?? [],
         },
       };
-    },
+    }
   );
 
   return {
@@ -181,6 +182,31 @@ export const getChatHistory = async (): ServerActionReturnType<
     return {
       success: true,
       data: chatHistorys,
+    };
+  } catch (e) {
+    return {
+      success: false,
+      error: (e as Error).message,
+    };
+  }
+};
+
+export const getUserData = async (): ServerActionReturnType<User> => {
+  const data = await auth();
+
+  if (!data || !data.user || !data.user.id) {
+    redirect("/signin");
+    return { error: "Not authenticated", success: false };
+  }
+
+  try {
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, data.user.id),
+    });
+
+    return {
+      success: true,
+      data: user,
     };
   } catch (e) {
     return {


### PR DESCRIPTION
### Summary

Implement a feature to display the user's profile page skeleton and update the header component to include the user's profile link.

### Details

- The `feat: profile page skeleton` pull request aims to introduce a feature that displays the user's profile page skeleton and update the header component to include the user's profile link.
- This pull request includes the following changes:
  - Removal of the `AddIcon` import from the `@repo/ui/icons` package in the `header.tsx` file.
  - Addition of a `userId` prop to the `Header` functional component in the `header.tsx` file.
  - Modification of the `Header` component to include a `Link` element that navigates to the user's profile page.
  - Addition of a `page.tsx` file under the `apps/web/app/(dash)/user/[userId]` folder, which defines a functional component for rendering the user's profile page skeleton.
  - Creation of a new `getUserData` function in the `fetchers.ts` file to fetch the logged-in user's data.
- Refactoring details:
  - The `Layout` functional component in the `layout.tsx` file is updated to pass the `userId` prop to the `Header` component.
  - The `Link` element in the `header.tsx` file is updated to construct the user's profile URL dynamically using the `userId` prop.
  - The updated `getUserData` function in the `fetchers.ts` file is designed to fetch the logged-in user's data using the Drizzle ORM query interface. It returns an object containing the fetched user data or an error message, along with a success status indicator.


> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
<img width="987" alt="image" src="https://github.com/Dhravya/supermemory/assets/38828053/2b582812-9950-4d70-a873-b050c9bd14b4">

</details>

