### PR TITLE
fixed link

### DIFF
--- a/apps/web/app/(landing)/Cta.tsx
+++ b/apps/web/app/(landing)/Cta.tsx
@@ -36,7 +36,7 @@ function Cta() {
       <div className="w-full lg:w-3/4 mx-auto">
         <Link
           href="/signin"
-          className="inline-flex gap-x-2 justify-start items-start py-3 px-5 ml-3 w-full rounded-3xl border duration-200 sm:w-auto group bg-page-gradient border-white/30 text-md font-geistSans hover:border-zinc-600 hover:bg-transparent/10 hover:text-zinc-100 text-white"
+          className="inline-flex gap-x-2 justify-start items-start py-3 px-5 ml-3 w-full rounded-3xl border duration-200 sm:w-auto group bg-page-gradient border-white/30 text-md font-geistSans hover:border-zinc-600 hover:bg-transparent/10 hover:text-zinc-100 text-white z-[1] relative"
         >
           Sign in
           <div className="flex overflow-hidden relative justify-center items-center ml-1 w-5 h-5">


### PR DESCRIPTION
### Summary

Resolved the sign-in link z-index issue for the rotating icons on the website.

### Details

- **Issue**: The pull request addressed the z-index problem with the sign-in link below the rotating icons.
- **Solution**: Added a z-index of 1 to the link element within the Cta.tsx component.
- **Impact**: The intended behavior of triggering the link and the TEXT ITSELF when clicking on the sign-in arrow has been restored.
- **Reference**: Please see the provided image for the comparison:[Image](https://github.com/Dhravya/supermemory/assets/133845351/130f757b-f110-42b8-a2ed-1153935fcbb8)
- **Code Change**: The z-index property was added dynamically using `z-[1]` with the relative positioning to ensure proper stacking order for elements in the CSS.

  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
## Note
I understand that "main" is usually not the right branch to create a PR, but I couldn't find the contribution guide or the designated branch for PRs. This is a production bug currently live on the website.

## Issue: Sign-In Link Z-Index Problem
The sign-in link below the rotating icons had a z-index issue. When someone clicks on the arrow inside the button, the link gets triggered but not the TEXT ITSELF, which is not the intended behavior. To resolve this, added a z-index of 1 to the link element.

## Reference 
![image](https://github.com/Dhravya/supermemory/assets/133845351/130f757b-f110-42b8-a2ed-1153935fcbb8)

</details>

