### PR TITLE
rename terms to tos

### DIFF
--- a/apps/web/app/(auth)/signin/page.tsx
+++ b/apps/web/app/(auth)/signin/page.tsx
@@ -80,7 +80,7 @@ async function Signin({
           </div>
           <div className="text-slate-500 mt-16 z-20">
             By continuing, you agree to the
-            <Link href="/terms" className="text-slate-200">
+            <Link href="/tos" className="text-slate-200">
               {" "}
               Terms of Service
             </Link>{" "}


### PR DESCRIPTION
### Summary

Renames the '/terms' page to '/tos' to fix a 404 error.

### Details

- The '/terms' page was returning a 404 error because the terms of service page is actually located at '/tos'.
- Updates the link in the Sign In page from '/terms' to '/tos' to correctly point to the terms of service page.
- This is a minor change to fix a broken link and ensure the terms of service page is accessible to users.
  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
The /terms page is giving a 404 error because the terms of service page is named /tos
</details>

