### PR TITLE
menu reduced size

### DIFF
--- a/apps/web/app/(dash)/menu.tsx
+++ b/apps/web/app/(dash)/menu.tsx
@@ -214,7 +214,7 @@ function Menu() {
                   className={`bg-[#2F353C] text-[#DBDEE1] max-h-[35vh] overflow-auto  focus-visible:ring-0 border-none focus-visible:ring-offset-0 mt-2 ${/^https?:\/\/\S+$/i.test(content) && "text-[#1D9BF0] underline underline-offset-2"}`}
                   id="content"
                   name="content"
-                  rows={8}
+                  rows={4}
                   placeholder="Start typing a note or paste a URL here. I'll remember it."
                   value={content}
                   onChange={(e) => setContent(e.target.value)}


### PR DESCRIPTION
### Summary

This pull request reduces the size of the Menu component.

### Details

- The `rows` attribute of the `textarea` element in the `Menu` component has been reduced from 8 to 4.
- This change aims to make the menu more compact and visually appealing.
- The menu previously occupied too much space on the screen, leading to this adjustment.
  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

